### PR TITLE
Fix HF dtype selection for Colab GPUs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [{ name = "SSKG", email = "dev@example.com" }]
 dependencies = [
   "fastapi",
   "uvicorn",
+  "httpx",
   "pydantic",
   "pydantic-settings",
   "pandas",


### PR DESCRIPTION
## Summary
- choose a safe torch dtype per accelerator when loading Hugging Face models so CUDA devices without bfloat16 (e.g. Colab T4) use float16
- log the dtype decision and move the model to the selected device/dtype when device_map is unavailable
- include httpx in the default dependencies so FastAPI's TestClient works in clean installs

## Testing
- pytest -q *(fails: downloading BAAI/bge-small-en-v1.5 is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e22ffad88320a94f3045efd18843